### PR TITLE
Move to Node 22

### DIFF
--- a/.github/actions/action-npm-build/action.yml
+++ b/.github/actions/action-npm-build/action.yml
@@ -3,7 +3,7 @@ name: Compliance check and build test
 inputs:
   node-version:
     required: false
-    default: 20
+    default: "22.11.0"
     type: string
   app-path:
     required: true

--- a/renovate-configs/package-rules-config.json5
+++ b/renovate-configs/package-rules-config.json5
@@ -6,7 +6,7 @@
       "description": "Limit dependencies directly related to Node to latest version on company machines",
       "matchDatasources": ["npm"],
       "matchPackageNames": ["@tsconfig/node-lts", "@types/node"],
-      "allowedVersions": "<=20.18.0"
+      "allowedVersions": "<=22.11.0"
     },
     {
       "description": "Limit Keycloak version in Docker stacks to latest version in company infrastructure, might slighty differ due to some RedHat KeyCloak versions not being available as Docker image",


### PR DESCRIPTION
**Description**
- Updated package rules to allow Node 22 dependencies when developing
- Updated node workflow to use Node `22.11.0` (same as machines)

**Reference**
Issues #56
