### PR TITLE
Add Action create-github-release

### DIFF
--- a/.github/actions/action-create-github-release/action.yml
+++ b/.github/actions/action-create-github-release/action.yml
@@ -1,0 +1,36 @@
+name: Create GitHub Release
+description: "Creates a GitHub Release of a Maven Artifact"
+inputs:
+  artifact-name:
+    required: true
+    type: string
+    description: "name of the artifact to download"
+  mvn-artifact-id:
+    required: true
+    type: string
+    description: "artifact name from pom"
+  release-version:
+    required: true
+    type: string
+    description: "Version to use when preparing a release (e.g., 1.2.3)"
+  jar-path:
+    required: true
+    type: string
+    description: "path to the artifacts (e.g. ./target/*.jar)"
+runs:
+  using: "composite"
+    steps:
+      - name: Download a single artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: ${{inputs.artifact-name}}
+      - name: Create GitHub Release
+        id: create_release
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
+        with:
+          tag_name: ${{inputs.mvn-artifact-id}}-${{inputs.release-version}}
+          draft: false
+          prerelease: false
+          generate_release_notes: false
+          files: |
+            ${{inputs.jar-path}}

--- a/workflow-templates/ release-maven-image.yaml
+++ b/workflow-templates/ release-maven-image.yaml
@@ -57,12 +57,9 @@ jobs:
     steps:
       - name: Create GitHub Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: it-at-m/.github/.github/actions/action-create-github-release@main
         with:
-          tag_name: ${{needs.release-maven.outputs.MVN_ARTIFACT_ID}}-${{ github.event.inputs.releaseVersion }}
-          draft: false
-          prerelease: false
-          generate_release_notes: false
-          draft: false
-          prerelease: false
-          generate_release_notes: false
+          artifact-name: ${{ needs.release-maven.outputs.ARTIFACT_NAME }}
+          mvn-artifact-id: ${{ needs.release-maven.outputs.MVN_ARTIFACT_ID }}
+          release-version: ${{ github.event.inputs.releaseVersion }}
+          jar-path: ${{ github.event.inputs.app-path }}/target/*.jar


### PR DESCRIPTION
**Description**

Add Action create-github-release to wrap external actions softprops/action-gh-release and actions/download-artifact

**Reference**

Issues #82 
