### PR TITLE
Disable overrides depedency updates

### DIFF
--- a/renovate-configs/package-rules-config.json5
+++ b/renovate-configs/package-rules-config.json5
@@ -3,6 +3,17 @@
   "description": "Renovate configuration for package rules to ignore packages which are dependent on internal infrastructure and tooling. Manual updates are necessary when new versions get rolled out.",
   "packageRules": [
     {
+      "description": "Disable major and minor updates for peer dependency overrides as compatibility is almost always not given",
+      "matchDepTypes": ["overrides"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+    {
+      "description": "Disable automerge for peer dependency overrides to draw attention to them still existing (should be reviewed when root dependency got updates)",
+      "matchDepTypes": ["overrides"],
+      "automerge": false
+    },
+    {
       "description": "Limit dependencies directly related to Node to latest version on company machines",
       "matchDatasources": ["npm"],
       "matchPackageNames": ["@tsconfig/node-lts", "@types/node"],

--- a/renovate-configs/package-rules-config.json5
+++ b/renovate-configs/package-rules-config.json5
@@ -3,13 +3,13 @@
   "description": "Renovate configuration for package rules to ignore packages which are dependent on internal infrastructure and tooling. Manual updates are necessary when new versions get rolled out.",
   "packageRules": [
     {
-      "description": "Disable major and minor updates for peer dependency overrides as compatibility is almost always not given",
+      "description": "Disable major and minor updates for dependency overrides as compatibility is almost always not given",
       "matchDepTypes": ["overrides"],
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false
     },
     {
-      "description": "Disable automerge for peer dependency overrides to draw attention to them still existing (should be reviewed when root dependency got updates)",
+      "description": "Disable automerge for dependency overrides to draw attention to them still existing (should be reviewed when root dependency got updates)",
       "matchDepTypes": ["overrides"],
       "automerge": false
     },


### PR DESCRIPTION
**Description**

- Disable Renovate dependency updates for major / minor for overrides dependencies, as it's likely to break, LCM effort is irrelevant here as overrides should be removed ASAP when root dependency is updated
- Disable Renovate automerge for overrides updates to draw attention to overrides still existing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to enhance handling of peer dependency updates and improve stability during automated dependency resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->