### PR TITLE
Update package-rules-config.json5

### DIFF
--- a/renovate-configs/package-rules-config.json5
+++ b/renovate-configs/package-rules-config.json5
@@ -23,13 +23,13 @@
       "description": "Limit Keycloak version in Docker stacks to latest version in company infrastructure, might slighty differ due to some RedHat KeyCloak versions not being available as Docker image",
       "matchDatasources": ["docker"],
       "matchPackageNames": ["quay.io/keycloak/keycloak", "keycloak/keycloak"],
-      "allowedVersions": "<=26.2"
+      "allowedVersions": "<=26.6"
     },
     {
       "description": "Limit Postgres version in Docker stacks to latest version in company infrastructure",
       "matchDatasources": ["docker"],
       "matchPackageNames": ["postgres"],
-      "allowedVersions": "<=17.4"
+      "allowedVersions": "<=18.4"
     }
   ],
   "helm-values": {


### PR DESCRIPTION
**Description**

- Updated Keycloak to 26.6 and Postgres to 18.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported Docker image version limits for Keycloak through 26.6.
  * Updated supported Docker image version limits for PostgreSQL through 18.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->